### PR TITLE
Fixed typos in SEIRD vignette

### DIFF
--- a/R/SEIRD.R
+++ b/R/SEIRD.R
@@ -329,7 +329,7 @@ setGeneric("R0", def = function(model) {
 #' @describeIn SEIRD Calculates basic reproduction number for SEIRD model
 #'
 #' The R0 parameter is given by:
-#' \deqn{R_0 = \beta/\gamma}
+#' \deqn{R_0 = \beta/(\gamma + \mu)}
 #'
 #' @param model an SEIRD model
 #'
@@ -339,5 +339,6 @@ setGeneric("R0", def = function(model) {
 setMethod("R0", "SEIRD", function(model) {
   beta <- model@transmission_parameters$beta
   gamma <- model@transmission_parameters$gamma
-  beta / gamma
+  mu <- model@transmission_parameters$mu
+  beta / (gamma + mu)
 })

--- a/man/SEIRD-class.Rd
+++ b/man/SEIRD-class.Rd
@@ -73,7 +73,8 @@ of the SEIR model.
 All initial conditions must sum up to 1.
 If the initial conditions provided to do not sum to 1, an error is thrown.
 
-\item \code{transmission_parameters<-}: Set transmission parameters (beta, kappa, gamma and mu) of the SEIR model.
+\item \code{transmission_parameters<-}: Set transmission parameters (beta, kappa, gamma and mu)
+of the SEIR model.
 
 If the transmission parameters provided to are not 1-dimensional an error is
 thrown.
@@ -94,7 +95,7 @@ This function relies on the package deSolve.
 \item \code{R0}: Calculates basic reproduction number for SEIRD model
 
 The R0 parameter is given by:
-\deqn{R_0 = \beta/\gamma}
+\deqn{R_0 = \beta/(\gamma + \mu)}
 }}
 
 \section{Slots}{

--- a/tests/testthat/test-SEIR.R
+++ b/tests/testthat/test-SEIR.R
@@ -90,13 +90,15 @@ test_that("R0 works for SEIRD model", {
   initial_conditions(my_model) <- list(S0=0.9, E0=0, I0=0.1, R0=0)
   beta <- 1.1
   gamma <- 0.4
+  mu <- 0.2
   transmission_parameters(my_model) <- list(beta=beta, kappa=0.1,
-                                            gamma=gamma, mu=0.3)
-  expect_equal(R0(my_model), beta/gamma)
+                                            gamma=gamma, mu=mu)
+  expect_equal(R0(my_model), beta/(gamma+mu))
   
   beta <- 1.4
   gamma <- 0.8
+  mu <- 0.1
   transmission_parameters(my_model) <- list(beta=beta, kappa=0.1,
-                                            gamma=gamma, mu=0.3)
-  expect_equal(R0(my_model), beta/gamma)
+                                            gamma=gamma, mu=mu)
+  expect_equal(R0(my_model), beta/(gamma+mu))
 })

--- a/vignettes/SEIRD.Rmd
+++ b/vignettes/SEIRD.Rmd
@@ -123,7 +123,7 @@ $$ \text{incidence(t)} = C(t) - C(t - 1),$$
 
 since this shows the number of cases which have arisen between these time  points. Deaths are also given by a difference, but, in this instance, between the cumulative number of deaths at two consecutive time points:
 
-$$ \text{deaths(t)} = C(t) - C(t - 1).$$
+$$ \text{deaths(t)} = D(t) - D(t - 1).$$
 
 ```{r fig2, fig.height = 5, fig.width = 7}
 changes <- out_df$changes
@@ -176,7 +176,7 @@ result %>%
 Why do some epidemics die out quickly but others don't? This is can be explored through the basic reproductive number, $R_0$, which is the expected number of people infected by a
 single infectious individual in a population where everyone is susceptible. Note that this basic reproductive number is unrelated to the initial condition for the recovered population! If $R_0>1$, an infectious individual infects more than one other person and the epidemic initially grows exponentially; if $R_0<1$, an infectious individual infects less than one other person and the epidemic dies out quickly. In an SEIRD model with normalized populations, the reproductive number is given by:
 
-$$R_0 = \beta/\gamma.$$
+$$R_0 = \beta S_0/\gamma.$$
 We now calculate $R_0$ for $\beta=0.1$ and $\beta=0.75$.
 ```{r, fig.height = 5, fig.width = 7}
 inits <- list(S0=0.99, E0=0, I0=0.01, R0=0)

--- a/vignettes/SEIRD.Rmd
+++ b/vignettes/SEIRD.Rmd
@@ -174,9 +174,9 @@ result %>%
 ```
 
 Why do some epidemics die out quickly but others don't? This is can be explored through the basic reproductive number, $R_0$, which is the expected number of people infected by a
-single infectious individual in a population where everyone is susceptible. Note that this basic reproductive number is unrelated to the initial condition for the recovered population! If $R_0>1$, an infectious individual infects more than one other person and the epidemic initially grows exponentially; if $R_0<1$, an infectious individual infects less than one other person and the epidemic dies out quickly. In an SEIRD model with normalized populations, the reproductive number is given by:
+single infectious individual in a population where everyone is susceptible (i.e $S_0 \approx 1$). Note that this basic reproductive number is unrelated to the initial condition for the recovered population! If $R_0>1$, an infectious individual infects more than one other person and the epidemic initially grows exponentially; if $R_0<1$, an infectious individual infects less than one other person and the epidemic dies out quickly. In an SEIRD model with normalized populations, the reproductive number is given by:
 
-$$R_0 = \beta S_0/\gamma.$$
+$$R_0 = \beta S_0/(\gamma + \mu).$$
 We now calculate $R_0$ for $\beta=0.1$ and $\beta=0.75$.
 ```{r, fig.height = 5, fig.width = 7}
 inits <- list(S0=0.99, E0=0, I0=0.01, R0=0)


### PR DESCRIPTION
Edited two bits:
1) fixed typo in the definition of deaths(t), which should depend on D(t), not C(t).
2) edited the definition of R_0. Although S_0 is one in the case of normalized population, for generalities sake I think it is better to give the full definition of R_0, especially as this corresponds to the definitions that people will find online.

## Issue
- [ ] Which issue does your pull request address? If none of the existing issues are applicable, you can write a new issue.

## Testing, documentation, and checks
- [ ] If your pull request introduces new code, you should write automated tests (explained [here](https://r-pkgs.org/tests.html)).
- [ ] Check that all tests pass using `devtools::check()`.
- [ ] Check compliance with the preferred R style using `lintr::lint_package()`.
- [ ] Build documentation using `devtools::document()`.
- [ ] If you changed the readme, run `knitr::knit("README.Rmd")`.

## Pull request
- [ ] Assign at least one reviewer.
